### PR TITLE
feat: ApiKeyForm を UI に表示しないようにする (from release/v10.0.0)

### DIFF
--- a/client/app/pages/users/components/EditableUserProfile.jsx
+++ b/client/app/pages/users/components/EditableUserProfile.jsx
@@ -1,10 +1,9 @@
-import React, { useState, useEffect } from "react";
 import { UserProfile } from "@/components/proptypes";
+import React, { useEffect, useState } from "react";
 
-import UserInfoForm from "./UserInfoForm";
-import ApiKeyForm from "./ApiKeyForm";
 import PasswordForm from "./PasswordForm";
 import ToggleUserForm from "./ToggleUserForm";
+import UserInfoForm from "./UserInfoForm";
 
 export default function EditableUserProfile(props) {
   const [user, setUser] = useState(props.user);
@@ -21,8 +20,6 @@ export default function EditableUserProfile(props) {
       <UserInfoForm user={user} onChange={setUser} />
       {!user.isDisabled && (
         <React.Fragment>
-          <ApiKeyForm user={user} onChange={setUser} />
-          <hr />
           <PasswordForm user={user} />
         </React.Fragment>
       )}

--- a/client/cypress/integration/user/edit_profile_spec.js
+++ b/client/cypress/integration/user/edit_profile_spec.js
@@ -27,19 +27,6 @@ describe("Edit Profile", () => {
     fillProfileDataAndSave("Example Admin", "admin@redash.io");
   });
 
-  it("regenerates API Key", () => {
-    cy.getByTestId("ApiKey").then($apiKey => {
-      const previousApiKey = $apiKey.val();
-
-      cy.getByTestId("RegenerateApiKey").click();
-      cy.get(".ant-btn-primary")
-        .contains("Regenerate")
-        .click({ force: true });
-
-      cy.getByTestId("ApiKey").should("not.eq", previousApiKey);
-    });
-  });
-
   it("renders the page and takes a screenshot", () => {
     cy.getByTestId("Groups").should("contain", "admin");
     cy.percySnapshot("User Profile");


### PR DESCRIPTION
## やったこと
Redash セキュリティ対策の観点から、設定画面に表示される `API Key`（User API Key）を表示できないようにする。

## Notion
https://www.notion.so/acesinc/0cb3cb7034f3403d96625eb2afcd3667?v=9f3e0c3566a647c09359d07a7956425b&p=c6325cee3bc5461e82e33a0829c311ea&pm=s
